### PR TITLE
Vault health check and namespace fix

### DIFF
--- a/pkg/internal/vault/fake/vault.go
+++ b/pkg/internal/vault/fake/vault.go
@@ -26,14 +26,18 @@ import (
 )
 
 type Vault struct {
-	NewFn  func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)
-	SignFn func([]byte, time.Duration) ([]byte, []byte, error)
+	NewFn                           func(string, corelisters.SecretLister, v1.GenericIssuer) (*Vault, error)
+	SignFn                          func([]byte, time.Duration) ([]byte, []byte, error)
+	IsVaultInitializedAndUnsealedFn func() error
 }
 
 func New() *Vault {
 	v := &Vault{
 		SignFn: func([]byte, time.Duration) ([]byte, []byte, error) {
 			return nil, nil, nil
+		},
+		IsVaultInitializedAndUnsealedFn: func() error {
+			return nil
 		},
 	}
 
@@ -71,4 +75,8 @@ func (v *Vault) New(ns string, sl corelisters.SecretLister, iss v1.GenericIssuer
 
 func (v *Vault) Sys() *vault.Sys {
 	return new(vault.Sys)
+}
+
+func (v *Vault) IsVaultInitializedAndUnsealed() error {
+	return nil
 }

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -111,9 +111,13 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 	request := v.client.NewRequest("POST", url)
 
 	if vaultIssuer.Namespace != "" {
-		vaultReqHeaders := http.Header{}
-		vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
-		request.Headers = vaultReqHeaders
+		if request.Headers != nil {
+			request.Headers.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+		} else {
+			vaultReqHeaders := http.Header{}
+			vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+			request.Headers = vaultReqHeaders
+		}
 	}
 
 	if err := request.SetJSONBody(parameters); err != nil {
@@ -261,9 +265,13 @@ func (v *Vault) requestTokenWithAppRoleRef(client Client, appRole *v1.VaultAppRo
 
 	vaultIssuer := v.issuer.GetSpec().Vault
 	if vaultIssuer.Namespace != "" {
-		vaultReqHeaders := http.Header{}
-		vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
-		request.Headers = vaultReqHeaders
+		if request.Headers != nil {
+			request.Headers.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+		} else {
+			vaultReqHeaders := http.Header{}
+			vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+			request.Headers = vaultReqHeaders
+		}
 	}
 
 	resp, err := client.RawRequest(request)

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -377,8 +377,8 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 
 func (v *Vault) IsVaultInitializedAndUnsealed() error {
 	healthURL := path.Join("/v1", "sys", "health")
-	heatlhRequest := v.client.NewRequest("GET", healthURL)
-	healthResp, err := v.client.RawRequest(heatlhRequest)
+	healthRequest := v.client.NewRequest("GET", healthURL)
+	healthResp, err := v.client.RawRequest(healthRequest)
 	// 429 = if unsealed and standby
 	// 472 = if disaster recovery mode replication secondary and active
 	// 473 = if performance standby

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -384,7 +384,7 @@ func (v *Vault) IsVaultInitializedAndUnsealed() error {
 
 func (v *Vault) addVaultNamespaceToRequest(request *vault.Request) {
 	vaultIssuer := v.issuer.GetSpec().Vault
-	if vaultIssuer.Namespace != "" {
+	if vaultIssuer != nil && vaultIssuer.Namespace != "" {
 		if request.Headers != nil {
 			request.Headers.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
 		} else {

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -258,6 +258,13 @@ func (v *Vault) requestTokenWithAppRoleRef(client Client, appRole *v1.VaultAppRo
 		return "", fmt.Errorf("error encoding Vault parameters: %s", err.Error())
 	}
 
+	vaultIssuer := v.issuer.GetSpec().Vault
+	if vaultIssuer.Namespace != "" {
+		vaultReqHeaders := http.Header{}
+		vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+		request.Headers = vaultReqHeaders
+	}
+
 	resp, err := client.RawRequest(request)
 	if err != nil {
 		return "", fmt.Errorf("error logging in to Vault server: %s", err.Error())

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -1039,7 +1039,9 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 			v := &Vault{
 				namespace:     "test-namespace",
 				secretsLister: test.fakeLister,
-				issuer:        nil,
+				issuer: gen.Issuer("vault-issuer",
+					gen.SetIssuerNamespace("namespace"),
+				),
 			}
 
 			token, err := v.requestTokenWithAppRoleRef(test.client, test.appRole)

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -110,16 +110,8 @@ func (v *Vault) Setup(ctx context.Context) error {
 		return err
 	}
 
-	health, err := client.Sys().Health()
-	if err != nil {
-		s := messageVaultHealthCheckFailed + err.Error()
-		logf.V(logf.WarnLevel).Infof("%s: %s", v.issuer.GetObjectMeta().Name, s)
-		apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, s)
-		return err
-	}
-
-	if !health.Initialized || health.Sealed {
-		logf.V(logf.WarnLevel).Infof("%s: %s: health: %v", v.issuer.GetObjectMeta().Name, messageVaultStatusVerificationFailed, health)
+	if err := client.IsVaultInitializedAndUnsealed(); err != nil {
+		logf.V(logf.WarnLevel).Infof("%s: %s: error: %s", v.issuer.GetObjectMeta().Name, messageVaultStatusVerificationFailed, err.Error())
 		apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorVault, messageVaultStatusVerificationFailed)
 		return fmt.Errorf(messageVaultStatusVerificationFailed)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes two issues: 
1. Approle login for HashiCorp vault is failing when namespaces were used in vault.  
2. The health check would mark the vault as sealed/un-initialised when the vault token did not have enough access to call the /sys endpoints. 

In order to fix the first issue, I added the `X-VAULT-NAMESPACE` header to the login API call. 

To fix the second issue, I had to move from making use of vault client's `client.Sys().Health()` to making direct API calls like we do for login etc. This is because when token passed to the vault does not have sufficient permissions to call the /sys/* endpoints, vault returns the correct HTTP status code, but an empty JSON response. In vault client's `client.Sys().Health()`, the team is replying purely on the JSON response of the vault and not the HTTP status code by setting the following parameters:
```golang
r.Params.Add("uninitcode", "299")
r.Params.Add("sealedcode", "299")
r.Params.Add("standbycode", "299")
r.Params.Add("drsecondarycode", "299")
r.Params.Add("performancestandbycode", "299")
``` 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3434

**Special notes for your reviewer**:
You will need an enterprise version of HashiCorp's Vault to fully test these changes. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed approle login when namespaces were used in HashiCorp Vault 
Fixed incorrectly failing health check that was caused when the Vault token did not have sufficient permission to call /sys/* endpoints 
```
